### PR TITLE
Revert "Added new fields "

### DIFF
--- a/plaso-geoip.json
+++ b/plaso-geoip.json
@@ -60,7 +60,7 @@
         "if": "ctx.ip_address =~ /[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+/"
       }
     }, {
-    },/* {
+    }, {
       "geoip": {
         "field": "ip_address",
         "database_file": "Anonymous.mmdb",
@@ -68,7 +68,7 @@
         "properties": ["country_iso_code"],
         "if": "ctx.ip_address =~ /[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+/"
       }
-    },  {
+    }, /* {
       "rename": {
         "field": "anonymous.country_iso_code", "target_field": "relay", "ignore_missing": true
       }

--- a/plaso-winevt.json
+++ b/plaso-winevt.json
@@ -53,7 +53,7 @@
         "field": "xml",
         "target_field": "target_username",
         "if": "ctx.xml=~/TargetUserName/",
-        "pattern": ".*<(Data.Name)=\"(TargetUserName)\">([^<]*)<.(Data)?(.|\\W)*",
+        "pattern": ".*<(Data.Name)=\"(TargetUserName)\">([^<]*)<.(Data).*",
         "replacement": "$3"
       }
     },  {
@@ -61,7 +61,7 @@
         "field": "xml",
         "target_field": "subject_username",
         "if": "ctx.xml=~/SubjectUserName/",
-        "pattern": ".*<(Data.Name)=\"(SubjectUserName)\">([^<]*)<.(Data)?(.|\\W)*",
+        "pattern": ".*<(Data.Name)=\"(SubjectUserName)\">([^<]*)<.(Data).*",
         "replacement": "$3"
       }
     },  /*{
@@ -81,76 +81,12 @@
     },  {
       "gsub": {
         "field": "xml",
-        "target_field": "svc_img_path",
-        "if": "ctx.source_name=='Service Control Manager' && ctx.event_id=='7045'",
-        "pattern": ".*<(Data.Name)=\"(ImagePath)\">([^<]*)<.(Data).*",
-        "replacement": "$3"
-      }
-    },{
-      "gsub": {
-        "field": "xml",
-        "target_field": "svc_name",
-        "if": "ctx.source_name=='Service Control Manager' && ctx.event_id=='7045'",
-        "pattern": ".*<(Data.Name)=\"(ServiceName)\">([^<]*)<.(Data).*",
-        "replacement": "$3"
-      }
-    },{
-      "gsub": {
-        "field": "xml",
-        "target_field": "parent_procname",
-        "if": "ctx.source_name=='Microsoft-Windows-Security-Auditing' && ctx.event_id=='4688'",
-        "pattern": ".*<(Data.Name)=\"(ParentProcessName)\">([^<]*)<.(Data).*",
-        "replacement": "$3"
-      }
-    },{
-      "gsub": {
-        "field": "xml",
-        "target_field": "child_procname",
-        "if": "ctx.source_name=='Microsoft-Windows-Security-Auditing' && ctx.event_id=='4688'",
-        "pattern": ".*<(Data.Name)=\"(NewProcessName)\">([^<]*)<.(Data).*",
-        "replacement": "$3"
-      }
-    },{
-      "gsub": {
-        "field": "xml",
-        "target_field": "proc_cmdline",
-        "if": "ctx.source_name=='Microsoft-Windows-Security-Auditing' && ctx.event_id=='4688'",
-        "pattern": ".*<(Data.Name)=\"(CommandLine)\">([^<]*)<.(Data).*",
-        "replacement": "$3"
-      }
-    },{
-      "gsub": {
-        "field": "xml",
-        "target_field": "svc_filename",
-        "if": "ctx.source_name=='Microsoft-Windows-Security-Auditing' && ctx.event_id=='4697'",
-        "pattern": ".*<(Data.Name)=\"(ServiceFileName)\">([^<]*)<.(Data).*",
-        "replacement": "$3"
-      }
-    },{
-      "gsub": {
-        "field": "xml",
-        "target_field": "schtask_name",
-        "if": "ctx.source_name=='Microsoft-Windows-Security-Auditing' && (ctx.event_id=='4698' || ctx.event_id=='4699' || ctx.event_id=='4702')",
-        "pattern": ".*<(Data.Name)=\"(TaskName)\">([^<]*)<.(Data).*",
-        "replacement": "$3"
-      }
-    },{
-      "gsub": {
-        "field": "xml",
-        "target_field": "schtask_cmd",
-        "if": "ctx.source_name=='Microsoft-Windows-Security-Auditing' && (ctx.event_id=='4698' || ctx.event_id=='4699' || ctx.event_id=='4702')",
-        "pattern": ".*<Command>([^<]*)<\/(Command.*",
-        "replacement": "$3"
-      }
-    },{
-      "gsub": {
-        "field": "xml",
         "target_field": "logon_process_name",
         "if": "ctx.xml=~/LogonProcessName/",
         "pattern": ".*<(Data.Name)=\"(LogonProcessName)\">([^<]*)<.(Data).*",
         "replacement": "$3"
       }
-    }, {
+    },  {
       "gsub": {
         "field": "xml",
         "target_field": "process_name",


### PR DESCRIPTION
Reverts InsaneTechnologies/elasticsearch-plaso-pipelines#2

@blueteam0ps :

There is an issue with the following bit of code in plaso-winevt.json


```
{
      "gsub": {
        "field": "xml",
        "target_field": "schtask_cmd",
        "if": "ctx.source_name=='Microsoft-Windows-Security-Auditing' && (ctx.event_id=='4698' || ctx.event_id=='4699' || ctx.event_id=='4702')",
        "pattern": ".*<Command>([^<]*)<\/(Command.*",
        "replacement": "$3"
      }
```
You've suggested value 3, but there's only brackets around 2 items ([^<]*) and (Command -- although the latter isn't closed.


